### PR TITLE
SpringBootEdu1-eatgo-1 Github issue Test && fastcampus 24th

### DIFF
--- a/eatgo-admin-api/src/main/java/kr/co/fastcampus/eatgo/application/CategoryService.java
+++ b/eatgo-admin-api/src/main/java/kr/co/fastcampus/eatgo/application/CategoryService.java
@@ -1,0 +1,29 @@
+package kr.co.fastcampus.eatgo.application;
+
+import kr.co.fastcampus.eatgo.domain.Category;
+import kr.co.fastcampus.eatgo.domain.CategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CategoryService {
+
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    public CategoryService (CategoryRepository categoryRepository){
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<Category> getCategories(){
+        return categoryRepository.findAll();
+    }
+
+    public Category addCategory(String name) {
+        Category category = Category.builder().name(name).build();
+        categoryRepository.save(category);
+        return category;
+    }
+}

--- a/eatgo-admin-api/src/main/java/kr/co/fastcampus/eatgo/application/RegionService.java
+++ b/eatgo-admin-api/src/main/java/kr/co/fastcampus/eatgo/application/RegionService.java
@@ -3,11 +3,12 @@ package kr.co.fastcampus.eatgo.application;
 import kr.co.fastcampus.eatgo.domain.Region;
 import kr.co.fastcampus.eatgo.domain.RegionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Service
 public class RegionService {
-
 
     private RegionRepository regionRepository;
 

--- a/eatgo-admin-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/CategoryController.java
+++ b/eatgo-admin-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/CategoryController.java
@@ -1,0 +1,39 @@
+package kr.co.fastcampus.eatgo.interfaces;
+
+import kr.co.fastcampus.eatgo.application.CategoryService;
+import kr.co.fastcampus.eatgo.domain.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+@RestController
+public class CategoryController {
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @GetMapping("/categories")
+    public List<Category> list(){
+        List<Category> categories = categoryService.getCategories();
+
+        return categories;
+    }
+
+    @PostMapping("/categories")
+    public ResponseEntity<?> create (@RequestBody Category resource) throws URISyntaxException {
+        String name = resource.getName();
+        Category category = categoryService.addCategory(name);
+
+        String url = "/categories/"+category.getId();
+
+        return ResponseEntity.created(new URI(url)).body("{}");
+    }
+
+}

--- a/eatgo-admin-api/src/test/java/kr/co/fastcampus/eatgo/application/CategoryServiceTests.java
+++ b/eatgo-admin-api/src/test/java/kr/co/fastcampus/eatgo/application/CategoryServiceTests.java
@@ -1,0 +1,57 @@
+package kr.co.fastcampus.eatgo.application;
+
+import kr.co.fastcampus.eatgo.domain.CategoryRepository;
+import kr.co.fastcampus.eatgo.domain.Category;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+public class CategoryServiceTests {
+
+    private CategoryService categoryService;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Before
+    public void setUp(){
+        MockitoAnnotations.initMocks(this);
+        categoryService = new CategoryService(categoryRepository);
+    }
+
+    @Test
+    public void getCategories(){
+
+        List<Category> mockCategories = new ArrayList<>();
+        mockCategories.add(Category.builder().name("Korean Food").build());
+
+        given(categoryRepository.findAll()).willReturn(mockCategories);
+
+        List<Category> categories = categoryService.getCategories();
+        Category Category = categories.get(0);
+
+        assertThat(Category.getName(), is("Korean Food"));
+
+    }
+
+    @Test
+    public void addCategory(){
+
+        Category category = categoryService.addCategory("Korean Food");
+
+        verify(categoryRepository).save(any());
+        assertThat(category.getName(), is("Korean Food"));
+
+    }
+
+}

--- a/eatgo-admin-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/CategoryControllerTests.java
+++ b/eatgo-admin-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/CategoryControllerTests.java
@@ -1,0 +1,64 @@
+package kr.co.fastcampus.eatgo.interfaces;
+
+import kr.co.fastcampus.eatgo.application.CategoryService;
+import kr.co.fastcampus.eatgo.domain.Category;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class) // spring boot 2.1 버전 테스트 -> 2.2는 또 다름
+@WebMvcTest(CategoryController.class) // RegionController 테스트
+public class CategoryControllerTests {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    private CategoryService categoryService;
+
+    @Test
+    public void list() throws Exception {
+
+        List<Category> categories = new ArrayList<>();
+        categories.add(Category.builder().name("Korean Food").build());
+
+        given(categoryService.getCategories()).willReturn(categories);
+
+        mvc.perform(get("/categories"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Korean Food")));
+    }
+
+    @Test
+    public void create() throws Exception {
+
+        Category category = Category.builder().name("Korean Food").build();
+
+        given(categoryService.addCategory("Korean Food")).willReturn(category);
+
+        mvc.perform(post("/categories")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\":\"Korean Food\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(content().string("{}"));
+
+        verify(categoryService).addCategory("Korean Food");
+
+    }
+}

--- a/eatgo-admin-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/RestaurantControllerTest.java
+++ b/eatgo-admin-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/RestaurantControllerTest.java
@@ -36,6 +36,7 @@ public class RestaurantControllerTest {
         List<Restaurant> restaurants = new ArrayList<>();
         restaurants.add(Restaurant.builder()
                 .id(1004L)
+                .categoryId(1L)
                 .name("JOKER House")
                 .address("Seoul")
                 .build());
@@ -56,11 +57,13 @@ public class RestaurantControllerTest {
     public void detailWithExisted() throws Exception {
         Restaurant restaurant = Restaurant.builder()
                                 .id(1004L)
+                                .categoryId(1L)
                                 .name("JOKER House")
                                 .address("Seoul")
                                 .build();
 
         given(restaurantService.getRestaurant(1004L)).willReturn(restaurant);
+
 
         mvc.perform(get("/restaurants/1004"))
                 .andExpect(status().isOk())
@@ -89,6 +92,7 @@ public class RestaurantControllerTest {
 
             return Restaurant.builder()
                     .id(1234L)
+                    .categoryId(1L)
                     .name(restaurant.getName())
                     .address(restaurant.getAddress())
                     .build();
@@ -96,7 +100,7 @@ public class RestaurantControllerTest {
 
         mvc.perform(post("/restaurants")
             .contentType(MediaType.APPLICATION_JSON)
-            .content("{\"name\":\"Beryong\", \"address\":\"busan\"}"))
+            .content("{\"name\":\"Beryong\", \"address\":\"busan\", \"categoryId\":1}"))
             .andExpect(status().isCreated())
             .andExpect(header().string("location", "/restaurants/1234"))
             .andExpect(content().string("{}"));
@@ -108,14 +112,14 @@ public class RestaurantControllerTest {
     public void createWithInvaildData() throws Exception {
         mvc.perform(post("/restaurants")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"\", \"address\":\"\"}"))
+                .content("{\"name\":\"\", \"address\":\"\", \"categoryId\":1}"))
                 .andExpect(status().isBadRequest());
     }
     @Test
     public void updateWithVaildData() throws Exception {
         mvc.perform(patch("/restaurants/1004")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"JOKER Bar\", \"address\":\"Busan\"}"))
+                .content("{\"name\":\"JOKER Bar\", \"address\":\"Busan\", \"categoryId\":1}"))
                 .andExpect(status().isOk());
 
         verify(restaurantService).updateRestaurant(1004L, "JOKER Bar", "Busan");
@@ -124,14 +128,14 @@ public class RestaurantControllerTest {
     public void updateWithInvaildData() throws Exception {
         mvc.perform(patch("/restaurants/1004")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"\", \"address\":\"\"}"))
+                .content("{\"name\":\"\", \"address\":\"\", \"categoryId\":1}"))
                 .andExpect(status().isBadRequest());
     }
     @Test
     public void updateWithoutName() throws Exception {
         mvc.perform(patch("/restaurants/1004")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"\", \"address\":\"Busan\"}"))
+                .content("{\"name\":\"\", \"address\":\"Busan\", \"categoryId\":1}"))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/eatgo-common/src/main/java/kr/co/fastcampus/eatgo/domain/Category.java
+++ b/eatgo-common/src/main/java/kr/co/fastcampus/eatgo/domain/Category.java
@@ -1,0 +1,22 @@
+package kr.co.fastcampus.eatgo.domain;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+}

--- a/eatgo-common/src/main/java/kr/co/fastcampus/eatgo/domain/CategoryRepository.java
+++ b/eatgo-common/src/main/java/kr/co/fastcampus/eatgo/domain/CategoryRepository.java
@@ -1,0 +1,12 @@
+package kr.co.fastcampus.eatgo.domain;
+
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface CategoryRepository extends CrudRepository<Category, Long> {
+
+    List<Category> findAll();
+
+    Category save(Category category);
+}

--- a/eatgo-common/src/main/java/kr/co/fastcampus/eatgo/domain/Restaurant.java
+++ b/eatgo-common/src/main/java/kr/co/fastcampus/eatgo/domain/Restaurant.java
@@ -8,6 +8,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,6 +23,9 @@ public class Restaurant {
     @GeneratedValue
     @Setter
     private Long id;
+
+    @NotNull
+    private Long categoryId;
 
     @NotEmpty
     private String name;

--- a/eatgo-common/src/main/java/kr/co/fastcampus/eatgo/domain/RestaurantRepository.java
+++ b/eatgo-common/src/main/java/kr/co/fastcampus/eatgo/domain/RestaurantRepository.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 public interface RestaurantRepository extends CrudRepository<Restaurant, Long> {
     List<Restaurant> findAll();
 
+    List<Restaurant> findAllByAddressContainingAndCategoryId(String region, long categoryId);
+
     Optional<Restaurant> findById(Long id);
 
     Restaurant save(Restaurant restaurant);

--- a/eatgo-common/src/test/java/kr/co/fastcampus/eatgo/domain/CategoryTests.java
+++ b/eatgo-common/src/test/java/kr/co/fastcampus/eatgo/domain/CategoryTests.java
@@ -1,0 +1,19 @@
+package kr.co.fastcampus.eatgo.domain;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class CategoryTests {
+
+    @Test
+    public void creation(){
+        Category category = Category.builder()
+                .name("Korean Food")
+                .build();
+
+        assertThat(category.getName(), is("Korean Food"));
+
+    }
+}

--- a/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/application/CategoryService.java
+++ b/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/application/CategoryService.java
@@ -1,0 +1,24 @@
+package kr.co.fastcampus.eatgo.application;
+
+import kr.co.fastcampus.eatgo.domain.Category;
+import kr.co.fastcampus.eatgo.domain.CategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CategoryService {
+
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    public CategoryService(CategoryRepository categoryRepository){
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<Category> getCategories(){
+        return categoryRepository.findAll();
+    }
+
+}

--- a/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/application/RegionService.java
+++ b/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/application/RegionService.java
@@ -3,11 +3,11 @@ package kr.co.fastcampus.eatgo.application;
 import kr.co.fastcampus.eatgo.domain.Region;
 import kr.co.fastcampus.eatgo.domain.RegionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 import java.util.List;
-
+@Service
 public class RegionService {
-
 
     private RegionRepository regionRepository;
 

--- a/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/application/RestaurantService.java
+++ b/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/application/RestaurantService.java
@@ -10,7 +10,6 @@ import java.util.List;
 @Service
 public class RestaurantService {
 
-
     private RestaurantRepository restaurantRepository;
 
     private MenuItemRepository menuItemRepository;
@@ -37,8 +36,9 @@ public class RestaurantService {
         return restaurant;
     }
 
-    public List<Restaurant> getRestaurants() {
-        List<Restaurant> restaurants = restaurantRepository.findAll();
+    public List<Restaurant> getRestaurants(String region, long categoryId) {
+
+        List<Restaurant> restaurants = restaurantRepository.findAllByAddressContainingAndCategoryId(region, categoryId);
         return restaurants;
     }
 

--- a/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/CategoryController.java
+++ b/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/CategoryController.java
@@ -1,0 +1,24 @@
+package kr.co.fastcampus.eatgo.interfaces;
+
+import kr.co.fastcampus.eatgo.application.CategoryService;
+import kr.co.fastcampus.eatgo.domain.Category;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class CategoryController {
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @GetMapping("/categories")
+    public List<Category> list(){
+        List<Category> categories = categoryService.getCategories();
+
+        return categories;
+    }
+
+}

--- a/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/RegionController.java
+++ b/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/RegionController.java
@@ -4,14 +4,9 @@ package kr.co.fastcampus.eatgo.interfaces;
 import kr.co.fastcampus.eatgo.application.RegionService;
 import kr.co.fastcampus.eatgo.domain.Region;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController

--- a/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/RestaurantController.java
+++ b/eatgo-customer-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/RestaurantController.java
@@ -3,10 +3,7 @@ package kr.co.fastcampus.eatgo.interfaces;
 import kr.co.fastcampus.eatgo.application.RestaurantService;
 import kr.co.fastcampus.eatgo.domain.Restaurant;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -18,8 +15,9 @@ public class RestaurantController {
     private RestaurantService restaurantService;
 
     @GetMapping("/restaurants")
-    public List<Restaurant> list() {
-        List<Restaurant> restaurants = restaurantService.getRestaurants();
+    public List<Restaurant> list(@RequestParam("region") String region, @RequestParam("category") Long categoryId) {
+
+        List<Restaurant> restaurants = restaurantService.getRestaurants(region, categoryId);
         return restaurants;
     }
     @GetMapping("/restaurants/{id}")

--- a/eatgo-customer-api/src/test/java/kr/co/fastcampus/eatgo/application/CategoryService.java
+++ b/eatgo-customer-api/src/test/java/kr/co/fastcampus/eatgo/application/CategoryService.java
@@ -1,0 +1,24 @@
+package kr.co.fastcampus.eatgo.application;
+
+import kr.co.fastcampus.eatgo.domain.Category;
+import kr.co.fastcampus.eatgo.domain.CategoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CategoryService {
+
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    public CategoryService(CategoryRepository categoryRepository){
+        this.categoryRepository = categoryRepository;
+    }
+
+    public List<Category> getCategories(){
+        return categoryRepository.findAll();
+    }
+
+}

--- a/eatgo-customer-api/src/test/java/kr/co/fastcampus/eatgo/application/RestaurantServiceTest.java
+++ b/eatgo-customer-api/src/test/java/kr/co/fastcampus/eatgo/application/RestaurantServiceTest.java
@@ -1,6 +1,5 @@
 package kr.co.fastcampus.eatgo.application;
 
-import kr.co.fastcampus.eatgo.application.RestaurantService;
 import kr.co.fastcampus.eatgo.domain.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,6 +56,7 @@ public class RestaurantServiceTest {
         //Restaurant restaurant = new Restaurant(1004L,"Bob zip", "Seoul");
         Restaurant restaurant = Restaurant.builder()
                 .id(1004L)
+                .categoryId(1L)
                 .name("Bob zip")
                 .address("Seoul")
                 .menuItems(new ArrayList<MenuItem>())
@@ -64,7 +64,8 @@ public class RestaurantServiceTest {
 
         restaurants.add(restaurant);
 
-        given(restaurantRepository.findAll()).willReturn(restaurants);
+        given(restaurantRepository.findAllByAddressContainingAndCategoryId("Seoul", 1L))
+                .willReturn(restaurants);
 
         given(restaurantRepository.findById(1004L))
                 .willReturn(Optional.of(restaurant));
@@ -85,7 +86,9 @@ public class RestaurantServiceTest {
 
     @Test
     public void getRestaurants(){
-        List<Restaurant> restaurants = restaurantService.getRestaurants();
+        String region = "Seoul";
+        Long categoryId = 1L;
+        List<Restaurant> restaurants = restaurantService.getRestaurants(region, categoryId);
 
         Restaurant restaurant = restaurants.get(0);
         assertThat(restaurant.getId(), is(1004L));

--- a/eatgo-customer-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/CategoryControllerTests.java
+++ b/eatgo-customer-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/CategoryControllerTests.java
@@ -1,0 +1,45 @@
+package kr.co.fastcampus.eatgo.interfaces;
+
+import kr.co.fastcampus.eatgo.application.CategoryService;
+import kr.co.fastcampus.eatgo.domain.Category;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class) // spring boot 2.1 버전 테스트 -> 2.2는 또 다름
+@WebMvcTest(CategoryController.class) // RegionController 테스트
+public class CategoryControllerTests {
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    private CategoryService categoryService;
+
+    @Test
+    public void list() throws Exception {
+
+        List<Category> categories = new ArrayList<>();
+        categories.add(Category.builder().name("Korean Food").build());
+
+        given(categoryService.getCategories()).willReturn(categories);
+
+        mvc.perform(get("/categories"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Korean Food")));
+    }
+
+}

--- a/eatgo-customer-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/RestaurantControllerTest.java
+++ b/eatgo-customer-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/RestaurantControllerTest.java
@@ -37,13 +37,14 @@ public class RestaurantControllerTest {
         List<Restaurant> restaurants = new ArrayList<>();
         restaurants.add(Restaurant.builder()
                 .id(1004L)
+                .categoryId(1L)
                 .name("JOKER House")
                 .address("Seoul")
                 .build());
 
-        given(restaurantService.getRestaurants()).willReturn(restaurants);
+        given(restaurantService.getRestaurants("Seoul", 1L)).willReturn(restaurants);
 
-        mvc.perform(get("/restaurants"))
+        mvc.perform(get("/restaurants?region=Seoul&category=1"))
         .andExpect(status().isOk())
                 .andExpect(content().string(
                         containsString("\"id\":1004")


### PR DESCRIPTION
24강 가게목록 필터링

CrudRepository
findAllBy~~~Containing
 like조건 검색 가능

https://arahansa.github.io/docs_spring/jpa.html
ctrl + f -> containing 으로 검색시 [표 4. 메소드 이름 안에서 지원되는 키워드들]

findAllByAddressContainingAndCategoryId
    -> where address like ~ and categoryId = ''